### PR TITLE
Fix nil map assignment

### DIFF
--- a/lbclient/projection.go
+++ b/lbclient/projection.go
@@ -158,7 +158,7 @@ func ExcludeRange(fld string, r [2]int, projection *Projection, sort *Sort) Rang
 
 // GetProjection returns the map representation of the range projection
 func (p RangeProjection) GetProjection() map[string]interface{} {
-	var ret map[string]interface{}
+	ret := make(map[string]interface{}, 5)
 	ret["field"] = p.field
 	ret["include"] = p.include
 	ret["range"] = p.rng
@@ -205,7 +205,7 @@ func ExcludeMatching(fld string, match Query, projection *Projection, sort *Sort
 
 // GetProjection returns the map representation of the match projection
 func (p MatchProjection) GetProjection() map[string]interface{} {
-	var ret map[string]interface{}
+	ret := make(map[string]interface{}, 5)
 	ret["field"] = p.field
 	ret["include"] = p.include
 	ret["match"] = p.q


### PR DESCRIPTION
This fixes a panic when generating a `RangeProjection` or `MapProjection`. The maps must be initialized before assignment can happen.

```
panic: assignment to entry in nil map [recovered]
        panic: assignment to entry in nil map [recovered]
        panic: assignment to entry in nil map

goroutine 1 [running]:
encoding/json.(*encodeState).marshal.func1(0xc000119ab8)
        /usr/local/go/src/encoding/json/encode.go:326 +0x9a
panic(0x6a4460, 0x755c90)
        /usr/local/go/src/runtime/panic.go:969 +0x166
encoding/json.(*encodeState).marshal.func1(0xc0001198b8)
        /usr/local/go/src/encoding/json/encode.go:326 +0x9a
panic(0x6a4460, 0x755c90)
        /usr/local/go/src/runtime/panic.go:969 +0x166
github.com/lightblue-platform/go-client/lbclient.MatchProjection.GetProjection(...)
        /home/peasters/go/pkg/mod/github.com/lightblue-platform/go-client@v0.0.0-20170322184708-19077c67f908/lbclient/projection.go:209
github.com/lightblue-platform/go-client/lbclient.(*Projection).AsMap(0xc000119478, 0xc000119488, 0x40a93c)
        /home/peasters/go/pkg/mod/github.com/lightblue-platform/go-client@v0.0.0-20170322184708-19077c67f908/lbclient/projection.go:23 +0x9b
github.com/lightblue-platform/go-client/lbclient.Projection.MarshalJSON(0xc0000a1a50, 0x1, 0x1, 0x40bab3, 0x6a8b80, 0x6b5b80, 0x40e001, 0x7fe0f84f50d8)
        /home/peasters/go/pkg/mod/github.com/lightblue-platform/go-client@v0.0.0-20170322184708-19077c67f908/lbclient/projection.go:30 +0x2b
```